### PR TITLE
WIP - [SXPJB] Add producer support to Kafka integration

### DIFF
--- a/src/main/kotlin/com/fsociety/ktor/kafka/common/model/KafkaRegistration.kt
+++ b/src/main/kotlin/com/fsociety/ktor/kafka/common/model/KafkaRegistration.kt
@@ -1,6 +1,7 @@
 package com.fsociety.ktor.kafka.common.model
 
 import com.fsociety.ktor.kafka.core.consumer.KtorKafkaConsumer
+import com.fsociety.ktor.kafka.core.producer.KtorKafkaProducer
 
 sealed interface KafkaRegistration<K, V> {
     val id: String
@@ -10,4 +11,9 @@ data class KtorKafkaConsumerRegistration<K, V>(
     override val id: String,
     val ktorKafkaConsumer: KtorKafkaConsumer<K, V>,
     val listener: (K, V) -> Unit,
+) : KafkaRegistration<K, V>
+
+data class KtorKafkaProducerRegistration<K, V>(
+    override val id: String,
+    val ktorKafkaProducer: KtorKafkaProducer<K, V>,
 ) : KafkaRegistration<K, V>

--- a/src/main/kotlin/com/fsociety/ktor/kafka/common/utils/Utils.kt
+++ b/src/main/kotlin/com/fsociety/ktor/kafka/common/utils/Utils.kt
@@ -3,7 +3,11 @@ package com.fsociety.ktor.kafka.common.utils
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.Serializer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.Properties
@@ -27,4 +31,21 @@ fun <K, V> createConsumer(
         put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     }
     return KafkaConsumer(props)
+}
+
+fun <K, V> createProducer(
+    bootstrapServers: String,
+    keySerializer: Serializer<K>,
+    valueSerializer: Serializer<V>,
+    vararg extraProperties: Pair<ProducerConfig, Any>,
+): Producer<K, V> {
+    val props = Properties().apply {
+        put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+        put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer::class.java)
+        put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer::class.java)
+        extraProperties.forEach {
+            put(it.first, it.second)
+        }
+    }
+    return KafkaProducer(props)
 }

--- a/src/main/kotlin/com/fsociety/ktor/kafka/core/builder/ProducerBuilder.kt
+++ b/src/main/kotlin/com/fsociety/ktor/kafka/core/builder/ProducerBuilder.kt
@@ -1,0 +1,55 @@
+package com.fsociety.ktor.kafka.core.builder
+
+import com.fsociety.ktor.kafka.common.model.KtorKafkaProducerRegistration
+import com.fsociety.ktor.kafka.common.utils.createProducer
+import com.fsociety.ktor.kafka.core.producer.KtorKafkaProducer
+import io.ktor.server.application.Application
+import org.apache.kafka.common.serialization.Serializer
+import java.util.UUID
+
+class ProducerBuilder<K, V>(
+    private val application: Application,
+) {
+    var id: String = UUID.randomUUID().toString()
+    var ktorKafkaProducer: KtorKafkaProducer<K, V>? = null
+
+    var bootstrapServers: String? = null
+    var topic: String? = null
+
+    var keySerializer: Serializer<K>? = null
+    var valueSerializer: Serializer<V>? = null
+
+    internal fun build(): KtorKafkaProducerRegistration<K, V> {
+        ktorKafkaProducer?.let { validProducer ->
+            return KtorKafkaProducerRegistration(id, validProducer)
+        }
+
+        val validValueSerializer = requireNotNull(valueSerializer) {
+            "Either producer or valueSerializer must be provided"
+        }
+
+        val validKeySerializer = requireNotNull(keySerializer) {
+            "Either producer or keySerializer must be provided"
+        }
+
+        val validBootstrapServers = requireNotNull(bootstrapServers) {
+            "Either producer, bootstrapServers, or kafka.bootstrapServers in environment must be provided"
+        }
+
+        val validTopic = requireNotNull(topic) {
+            "Either producer or topic must be provided"
+        }
+
+        return KtorKafkaProducerRegistration(
+            id = id,
+            ktorKafkaProducer = KtorKafkaProducer(
+                kafkaProducer = createProducer(
+                    bootstrapServers = validBootstrapServers,
+                    keySerializer = validKeySerializer,
+                    valueSerializer = validValueSerializer,
+                ),
+                topic = validTopic,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/fsociety/ktor/kafka/core/producer/KtorKafkaProducer.kt
+++ b/src/main/kotlin/com/fsociety/ktor/kafka/core/producer/KtorKafkaProducer.kt
@@ -1,0 +1,71 @@
+package com.fsociety.ktor.kafka.core.producer
+
+import com.fsociety.ktor.kafka.common.utils.logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import java.util.concurrent.atomic.AtomicBoolean
+
+class KtorKafkaProducer<K, V>(
+    private val kafkaProducer: Producer<K, V>,
+    private val topic: String,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+) {
+    private val logger = logger()
+    private val isClose = AtomicBoolean(false)
+
+    fun send(message: V) {
+        val record = ProducerRecord<K, V>(topic, message)
+        send(record)
+    }
+
+    fun send(message: V, key: K) {
+        val record = ProducerRecord(topic, key, message)
+        send(record)
+    }
+
+    fun send(record: ProducerRecord<K, V>) {
+        send(record) { metadata, exception ->
+            if (exception != null) {
+                logger.error(ERROR_SENDING_MESSAGE_EVENT, exception)
+            } else {
+                logger.debug(
+                    PRODUCER_SENT_MESSAGE_EVENT,
+                    metadata.topic(),
+                    metadata.partition(),
+                    metadata.offset(),
+                )
+            }
+        }
+    }
+
+    fun send(record: ProducerRecord<K, V>, callback: (metadata: RecordMetadata, exception: Exception?) -> Unit) {
+        if (!isClose.compareAndSet(false, true)) {
+            logger.warn(PRODUCER_IS_CLOSE_EVENT)
+            return
+        }
+        scope.launch {
+            runCatching {
+                kafkaProducer.send(record, callback)
+            }.onFailure {
+                logger.error(ERROR_SENDING_MESSAGE_EVENT, it)
+            }
+        }
+    }
+
+    fun close() {
+        isClose.set(true)
+        kafkaProducer.close()
+        scope.cancel()
+    }
+
+    companion object {
+        private const val PRODUCER_IS_CLOSE_EVENT = "Producer is closed. Cannot send message."
+        private const val PRODUCER_SENT_MESSAGE_EVENT = "Message sent to topic: '{}', partition:'{}', offset: '{}'"
+        private const val ERROR_SENDING_MESSAGE_EVENT = "Error while sending kafka message."
+    }
+}

--- a/src/main/kotlin/com/fsociety/ktor/kafka/core/registration/KafkaRegistrationHandler.kt
+++ b/src/main/kotlin/com/fsociety/ktor/kafka/core/registration/KafkaRegistrationHandler.kt
@@ -2,6 +2,7 @@ package com.fsociety.ktor.kafka.core.registration
 
 import com.fsociety.ktor.kafka.common.model.KafkaRegistration
 import com.fsociety.ktor.kafka.common.model.KtorKafkaConsumerRegistration
+import com.fsociety.ktor.kafka.common.model.KtorKafkaProducerRegistration
 import com.fsociety.ktor.kafka.plugin.KtorKafkaPlugin
 
 class KafkaRegistrationHandler(
@@ -10,17 +11,27 @@ class KafkaRegistrationHandler(
 
     fun <K, V> handle(registration: KafkaRegistration<K, V>) {
         when (registration) {
-            is KtorKafkaConsumerRegistration -> registerConsumer(registration)
+            is KtorKafkaConsumerRegistration -> add(registration)
+            is KtorKafkaProducerRegistration -> add(registration)
         }
     }
 
-    private fun <K, V> registerConsumer(
-        registration: KtorKafkaConsumerRegistration<K, V>,
+    private fun <K, V> add(
+        ktorKafkaConsumer: KtorKafkaConsumerRegistration<K, V>,
     ) {
         plugin.addConsumer(
-            id = registration.id,
-            consumer = registration.ktorKafkaConsumer,
-            listener = registration.listener,
+            id = ktorKafkaConsumer.id,
+            consumer = ktorKafkaConsumer.ktorKafkaConsumer,
+            listener = ktorKafkaConsumer.listener,
+        )
+    }
+
+    private fun <K, V> add(
+        ktorKafkaProducer: KtorKafkaProducerRegistration<K, V>,
+    ) {
+        plugin.addProducer(
+            id = ktorKafkaProducer.id,
+            producer = ktorKafkaProducer.ktorKafkaProducer,
         )
     }
 }

--- a/src/main/kotlin/com/fsociety/ktor/kafka/core/registration/manager/KtorKafkaProducerManager.kt
+++ b/src/main/kotlin/com/fsociety/ktor/kafka/core/registration/manager/KtorKafkaProducerManager.kt
@@ -1,0 +1,28 @@
+package com.fsociety.ktor.kafka.core.registration.manager
+
+import com.fsociety.ktor.kafka.common.utils.logger
+import com.fsociety.ktor.kafka.core.producer.KtorKafkaProducer
+
+class KtorKafkaProducerManager {
+    private val logger = logger()
+    private val producers = mutableMapOf<String, KtorKafkaProducer<*, *>>()
+
+    fun <K, V> create(
+        id: String,
+        producer: KtorKafkaProducer<K, V>,
+    ) {
+        if (producers.containsKey(id)) {
+            logger.warn("Kafka producer $id is already registered")
+            return
+        }
+        producers[id] = producer
+        logger.info("Producer $id is registered")
+    }
+
+    fun closeAll() {
+        producers.forEach { (id, producer) ->
+            logger.info("Closing kafka producer with id $id")
+            producer.close()
+        }
+    }
+}


### PR DESCRIPTION
## Kafka Producer Support

Added support for Kafka producers to the Ktor Kafka plugin, enabling applications to easily send messages to Kafka topics. This implementation includes:

- New `KtorKafkaProducer` class for sending messages to Kafka topics
- `ProducerBuilder` for configuring and creating producer instances
- Producer management system with proper lifecycle handling
- Integration with the existing plugin architecture

This enhancement complements the existing consumer functionality, providing a complete Kafka integration solution for Ktor applications.